### PR TITLE
Remove bumpversion configuration file

### DIFF
--- a/{{cookiecutter.dist_name}}/.bumpversion.cfg
+++ b/{{cookiecutter.dist_name}}/.bumpversion.cfg
@@ -1,7 +1,0 @@
-[bumpversion]
-current_version = 0.2.0
-commit = True
-tag = True
-tag_name = {new_version}
-message = Bump version to {new_version}
-files = src/{{ cookiecutter.package_name }}/__init__.py pyproject.toml


### PR DESCRIPTION
## Summary
- delete bumpversion configuration to rely on PDM SCM

## Testing
- `tox -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d3e927248333b4f210b8697070cb