### PR TITLE
Add SCM versioning table

### DIFF
--- a/{{cookiecutter.dist_name}}/README.md
+++ b/{{cookiecutter.dist_name}}/README.md
@@ -60,6 +60,7 @@ pdm run bump-patch
 pdm run bump-minor
 pdm run bump-major
 ```
+The project version is derived from Git tags via the `pdm-bump` plugin, so tagging a release automatically updates the package version.
 
 
 ### Build the Project

--- a/{{cookiecutter.dist_name}}/pyproject.toml
+++ b/{{cookiecutter.dist_name}}/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 Documentation = "{{ cookiecutter.docs_url }}"
 Source = "{{ cookiecutter.repository_url }}"
 
+[tool.pdm.version]
+source = "scm"
+
 
 [tool.mypy]
 files = ["{{cookiecutter.package_name}}"]


### PR DESCRIPTION
## Summary
- add `[tool.pdm.version]` section for scm-based versions
- note git tag driven versioning via `pdm-bump` in README

## Testing
- `tox -q`


------
https://chatgpt.com/codex/tasks/task_e_6845cca103f8833388497e87c814aef2